### PR TITLE
Corrección de errores método que permite ilimitar saldo

### DIFF
--- a/src/model/Wallet.java
+++ b/src/model/Wallet.java
@@ -49,6 +49,7 @@ public class Wallet {
             return "Error. Romper el limite tiene un costo de 10000, usted tiene " + saldo;
         }
         saldo -= 10000;
+        tieneLimite = false;
         return "Operación exitosa. Su cuenta ahora es sin límites, nuevo saldo: " + saldo;
     }
     


### PR DESCRIPTION
Olvidé cambiar el valor del atributo "tieneLimite" a false, como estaba anteriormente se le hacía un cobro por nada